### PR TITLE
Single urlencode masking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "include-path": ["/../"],
   "require" :
   {
-    "php": "^5.5",
+    "php": "~5.5 || ~7.0",
     "phoxy/enjs": "~2.1.8"
   },
   "suggest" :

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require" :
   {
     "php": "~5.5 || ~7.0",
-    "phoxy/enjs": "~2.1.8"
+    "phoxy/enjs": "~2.2.1"
   },
   "suggest" :
   {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "include-path": ["/../"],
   "require" :
   {
-    "php": "~5.5",
+    "php": "^5.5",
     "phoxy/enjs": "~2.1.8"
   },
   "suggest" :

--- a/phoxy.js
+++ b/phoxy.js
@@ -48,7 +48,12 @@ var phoxy =
     {
       active: {},
       finished: {}
-    }
+    },
+    wait:
+    {
+      timeout_seconds: 20,
+      check_every_ms: 200,
+    },
   },
   _:
   {

--- a/phoxy.js
+++ b/phoxy.js
@@ -28,6 +28,7 @@ var phoxy =
       active : []
     },
     verbose : typeof phoxy.verbose === 'undefined' ? 10 : phoxy.verbose,
+    verbose_birth : typeof phoxy.verbose_birth === 'undefined' ? 1 : phoxy.verbose_birth,
     early:
     {
       require: 0,

--- a/server/api.php
+++ b/server/api.php
@@ -127,6 +127,14 @@ class api
     $compiled = default_addons($phoxy_loading_module);
 
     $this->default_addons = array_merge_recursive($compiled, $this->addons);
+
+    $this->default_addons =
+      $this->override_addons_on_init($this->default_addons);
+  }
+
+  public function override_addons_on_init($addons)
+  {
+    return $addons;
   }
 
   public function APICall( $name, $arguments )

--- a/server/api.php
+++ b/server/api.php
@@ -81,7 +81,7 @@ class phoxy_sys_api
     {
       if (isset($d[$name])) // directly return [function: data] values
         return $d[$name];
-      if ($this->expect_simple_result)
+      if ($this->expect_simple_result && !isset($d[0])) // only associative arrays could contain simple results
         foreach ($d as $val)
           return $val;
     }

--- a/server/api.php
+++ b/server/api.php
@@ -51,9 +51,6 @@ class phoxy_sys_api
   {
     $ret = $this->Call($name, $arguments);
 
-    if (is_a($ret, 'phoxy_return_worker'))
-      $ret = $ret->obj;
-
     if (!is_array($ret))
       return $ret;
 
@@ -92,8 +89,14 @@ class phoxy_sys_api
   private function Call( $name, $arguments )
   {
     $this->obj->json = false;
-    return call_user_func_array(array($this->obj, $name), $arguments);
+    $result = call_user_func_array(array($this->obj, $name), $arguments);
+
+    if (is_a($result, 'phoxy_return_worker'))
+      return $result->obj;
+
+    return $result;
   }
+
   private function ShouldRawReturn( $name )
   {
     if ($this->f)

--- a/server/api.php
+++ b/server/api.php
@@ -50,6 +50,7 @@ class phoxy_sys_api
   public function __call( $name, $arguments )
   {
     $ret = $this->Call($name, $arguments);
+
     if (is_a($ret, 'phoxy_return_worker'))
       $ret = $ret->obj;
 
@@ -148,6 +149,7 @@ class api
 
     $this->addons = $this->default_addons;
     $ret = $this->Call($name, $arguments);
+
     if (!is_array($ret))
     {
       $ret = [$name => $ret];

--- a/server/api.php
+++ b/server/api.php
@@ -52,7 +52,7 @@ class phoxy_sys_api
     $ret = $this->Call($name, $arguments);
 
     // raw calls do not affects restrictions
-    if (isset($ret['cache']) && !$this->f)
+    if (!$this->f)
       phoxy_return_worker::NewCache($ret['cache']);
 
     if (!empty($ret['data'][$name]))

--- a/server/api.php
+++ b/server/api.php
@@ -40,7 +40,7 @@ class phoxy_sys_api
   private $f;
   private $expect_simple_result;
 
-  public function phoxy_sys_api( $obj, $force_raw = false, $expect_simple_result = false )
+  public function __construct( $obj, $force_raw = false, $expect_simple_result = false )
   {
     $this->obj = $obj;
     $this->f = $force_raw;
@@ -186,11 +186,6 @@ class api
   private function AddPrefix( &$where, $what )
   {
     $where = "{$what}{$where}";
-  }
-
-  public function __invoke()
-  {
-    return $this->Reserve();
   }
 
   public function fork($force_raw = false, $expect_simple_result = true)

--- a/server/config.php
+++ b/server/config.php
@@ -13,12 +13,11 @@ function phoxy_default_conf()
     "js_prefix" => null,
     "ejs_prefix" => null,
     "api_prefix" => null,
-    "cache_global" => "1d",
+    "cache_global" => null,
     "cache_session" => null,
     "cache_local" => null,
     "autostart" => true,
     "api_xss_prevent" => true,
-    "cache" => ["session" => "1h"]
   ];
 }
 

--- a/server/config.php
+++ b/server/config.php
@@ -19,7 +19,7 @@ function phoxy_default_conf()
     "cache_session" => null,
     "cache_local" => null,
     "autostart" => true,
-    "api_xss_prevent" => true,
+    "api_csrf_prevent" => true,
   ];
 }
 

--- a/server/config.php
+++ b/server/config.php
@@ -20,6 +20,7 @@ function phoxy_default_conf()
     "cache_local" => null,
     "autostart" => true,
     "api_csrf_prevent" => true,
+    "sync_cascade" => false,
   ];
 }
 

--- a/server/config.php
+++ b/server/config.php
@@ -21,6 +21,7 @@ function phoxy_default_conf()
     "autostart" => true,
     "api_csrf_prevent" => true,
     "sync_cascade" => false,
+    "buffered_output" => true,
   ];
 }
 

--- a/server/config.php
+++ b/server/config.php
@@ -6,6 +6,8 @@ function phoxy_default_conf()
   [
     "ip" => $_SERVER['REMOTE_ADDR'],
     "site" => "http://".$_SERVER['HTTP_HOST']."/",
+    "debug_api" => true,
+    "is_ajax_request" => @$_SERVER['HTTP_X_LAIN'] === 'Wake up',
     "ejs_dir" => "ejs",
     "js_dir" => "js",
     "api_dir" => "api",

--- a/server/include.php
+++ b/server/include.php
@@ -43,10 +43,12 @@ function IncludeModule( $dir, $module )
 
     $classname = $module;
     $cross_include = class_exists($classname);
-    include_once($file);
+
 
     if ($cross_include)
       include('virtual_namespace_helper.php');
+    else
+      include_once($file);
 
     if (!class_exists($classname))
       die('Class include failed. File do not carrying that');

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -30,8 +30,8 @@ class phoxy extends api
   public static function Start()
   {
     global $_SERVER;
-    if (phoxy_conf()["api_xss_prevent"] && $_SERVER['HTTP_X_LAIN'] !== 'Wake up')
-      die("Request aborted due API direct XSS warning");
+    if (!phoxy_conf()["is_ajax_request"] && phoxy_conf()["api_csrf_prevent"])
+      die("Request aborted due API direct CSRF warning");
 
     global $_GET;
     $get_param = phoxy::Config()["get_api_param"];

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -60,4 +60,30 @@ class phoxy extends api
       echo new phoxy_return_worker($e->result);
     }
   }
+
+  public static function SetCacheTimeout($scope, $timeout)
+  {
+    if (is_integer($timeout))
+      return phoxy::SetCacheTimeout($scope, "{$timeout}s");
+
+    phoxy_return_worker::NewCache([$scope => $timeout]);
+  }
+
+  public static function SetCacheTimeoutTimestamp($scope, $timeout_timestamp)
+  {
+    if (!is_numeric($timeout_timestamp))
+    {
+      $dt = new DateTime($timeout_timestamp);
+      $unix_time = $dt->format('U'); // in server timezone
+
+      $timeout_timestamp = $unix_time;
+    }
+
+    $timeout = $timeout_timestamp - time();
+
+    if ($timeout < 0)
+      $timeout = 0;
+
+    phoxy::SetCacheTimeout($scope, $timeout);
+  }
 }

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -14,8 +14,8 @@ class phoxy extends api
     return phoxy_conf();
   }
 
-  // Calling phoxy::Load immideatelly loading or using preloaded module object
-  public static function Load($name)
+  // Calling phoxy::Load immediately loading or using preloaded module object
+  public static function Load($name, $raw_include = true)
   {
     $dir = phoxy::Config()['api_dir'];
     $names = explode('/', $name);
@@ -23,7 +23,7 @@ class phoxy extends api
     $module = array_pop($names);
     $directory = $dir.'/'.implode('/', $names);
 
-    return LoadModule($directory, $module, true);
+    return LoadModule($directory, $module, $raw_include);
   }
 
   // Begin default phoxy behaviour

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -15,7 +15,7 @@ class phoxy extends api
   }
 
   // Calling phoxy::Load immediately loading or using preloaded module object
-  public static function Load($name, $raw_include = true)
+  public static function Load($name, $raw_include = false)
   {
     $dir = phoxy::Config()['api_dir'];
     $names = explode('/', $name);

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -33,6 +33,9 @@ class phoxy extends api
     if (!phoxy_conf()["is_ajax_request"] && phoxy_conf()["api_csrf_prevent"])
       die("Request aborted due API direct CSRF warning");
 
+    if (phoxy_conf()["buffered_output"])
+      ob_start();
+
     global $_GET;
     $get_param = phoxy::Config()["get_api_param"];
     $file = $_GET[$get_param];
@@ -62,12 +65,24 @@ class phoxy extends api
 
     $prepared = (string)$result;
 
+    if (phoxy_conf()["buffered_output"])
+    {
+      $buffered_output = ob_get_contents();
+      ob_end_clean();
+    }
+
     if (phoxy_conf()["debug_api"] && !phoxy_conf()["is_ajax_request"])
+    {
+      echo "<h1>Result</h1>\n";
       var_dump($result->obj);
+    }
     else
       header('Content-Type: application/json; charset=utf-8');
 
-    echo $prepared;
+    if (phoxy_conf()["is_ajax_request"])
+      echo $prepared;
+    else if (phoxy_conf()["buffered_output"])
+      echo "\n<hr><h1>Log</h1>\n{$buffered_output}";
   }
 
   public static function SetCacheTimeout($scope, $timeout)

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -15,7 +15,7 @@ class phoxy extends api
   }
 
   // Calling phoxy::Load immediately loading or using preloaded module object
-  public static function Load($name, $raw_include = false)
+  public static function Load($name, $force_raw_return = false)
   {
     $dir = phoxy::Config()['api_dir'];
     $names = explode('/', $name);

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -60,10 +60,14 @@ class phoxy extends api
       $result = new phoxy_return_worker($e->result);
     }
 
-    if (phoxy_conf()["debug_api"] && !phoxy_conf()["is_ajax_request"])
-      var_dump($result);
+    $prepared = (string)$result;
 
-    echo $result;
+    if (phoxy_conf()["debug_api"] && !phoxy_conf()["is_ajax_request"])
+      var_dump($result->obj);
+    else
+      header('Content-Type: application/json; charset=utf-8');
+
+    echo $prepared;
   }
 
   public static function SetCacheTimeout($scope, $timeout)

--- a/server/phoxy.php
+++ b/server/phoxy.php
@@ -54,11 +54,16 @@ class phoxy extends api
       if (is_string($method))
         $method = [$method, []];
 
-      echo $a->APICall($method[0], $method[1]);
+      $result = $a->APICall($method[0], $method[1]);
     } catch (phoxy_protected_call_error $e)
     {
-      echo new phoxy_return_worker($e->result);
+      $result = new phoxy_return_worker($e->result);
     }
+
+    if (phoxy_conf()["debug_api"] && !phoxy_conf()["is_ajax_request"])
+      var_dump($result);
+
+    echo $result;
   }
 
   public static function SetCacheTimeout($scope, $timeout)

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -177,7 +177,7 @@ class phoxy_return_worker
     if ($str == 'no')
       return -1;
 
-    $arr = preg_split('/([0-9]+)([dhms]?)/', $str, -1, PREG_SPLIT_DELIM_CAPTURE);
+    $arr = preg_split('/([0-9]+)([wdhms]?)/', $str, -1, PREG_SPLIT_DELIM_CAPTURE);
 
     phoxy_protected_assert(count($arr) > 1, "Cache string parse error");
 
@@ -192,6 +192,8 @@ class phoxy_return_worker
       $mult = 1;
       switch ($modifyer)
       {
+      case 'w':
+        $mult *= 7;
       case 'd':
         $mult *= 24;
       case 'h':

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -121,8 +121,11 @@ class phoxy_return_worker
 
     if (!isset($cache['no']))
       $no = [];
-    else
+    else if (is_string($cache['no']))
       $no = explode(',', $cache['no']);
+    else
+      $no = $cache['no'];
+
     $dictionary = ["global", "session", "local"];
 
     foreach ($dictionary as $scope)

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -32,11 +32,27 @@ class phoxy_return_worker
         call_user_func(self::$add_hook_cb, $this);
   }
 
+  // http://stackoverflow.com/a/38398648
+  private function array_utf8_encode($dat)
+  {
+      if (is_string($dat))
+          return utf8_encode($dat);
+      if (!is_array($dat))
+          return $dat;
+      $ret = array();
+      foreach ($dat as $i => $d)
+          $ret[$i] = self::array_utf8_encode($d);
+      return $ret;
+  }
+
   private function Prepare()
   {
     foreach ($this->hooks as $hook)
         $hook($this);
-    return $this->prepared = json_encode($this->obj, JSON_UNESCAPED_UNICODE);
+
+    $force_utf8 = $this->array_utf8_encode($this->obj);
+
+    return $this->prepared = json_encode($force_utf8, JSON_UNESCAPED_UNICODE);
   }
 
   public function __toString()

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -199,6 +199,9 @@ class phoxy_return_worker
 
   static public function NewCache( $array )
   {
+    if (empty($array))
+      return; // ignore fictive values
+
     if (!is_array($array))
       return self::ProcessCache('global', $array);
     foreach ($array as $key => $value)

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -32,27 +32,15 @@ class phoxy_return_worker
         call_user_func(self::$add_hook_cb, $this);
   }
 
-  // http://stackoverflow.com/a/38398648
-  private function array_utf8_encode($dat)
-  {
-      if (is_string($dat))
-          return utf8_encode($dat);
-      if (!is_array($dat))
-          return $dat;
-      $ret = array();
-      foreach ($dat as $i => $d)
-          $ret[$i] = self::array_utf8_encode($d);
-      return $ret;
-  }
-
   private function Prepare()
   {
     foreach ($this->hooks as $hook)
         $hook($this);
 
-    $force_utf8 = $this->array_utf8_encode($this->obj);
+    $this->prepared = json_encode($this->obj, JSON_UNESCAPED_UNICODE);
 
-    return $this->prepared = json_encode($force_utf8, JSON_UNESCAPED_UNICODE);
+    if (!$this->prepared)
+      throw new phoxy_protected_call_error("Unable to encode json: ".json_last_error_msg());
   }
 
   public function __toString()

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -146,14 +146,14 @@ class phoxy_return_worker
     $cache = $this->obj['cache'];
 
     // If both session and global set, privacy has a priority
-    if (isset($cache['session']))
+    if (isset($cache['session']) && $cache['session'] != 'no')
     {
       header('Cache-Control: private, max-age='.self::ParseCache($cache['session']));
 
       return;
     }
 
-    if (isset($cache['global']))
+    if (isset($cache['global']) && $cache['global'] != 'no')
     {
       header('Cache-Control: public, max-age='.self::ParseCache($cache['global']));
 
@@ -162,7 +162,9 @@ class phoxy_return_worker
 
     if (isset($cache['no']))
     {
-      if (in_array(['global', 'session'], $cache['no']))
+      $find = array_intersect(['global', 'session'], $cache['no']);
+
+      if (count($find) > 0)
         header('Cache-Control: no-cache, no-store');
 
       return;

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -146,21 +146,28 @@ class phoxy_return_worker
   {
     $cache = $this->obj['cache'];
 
-    if (isset($cache['no']))
-    {
-      if (in_array('global', $cache['no'])
-          || in_array('all', $cache['no']))
-        header('Cache-Control: no-cache, no-store');
-    }
-    else if (isset($cache['session']))
+    // If both session and global set, privacy has a priority
+    if (isset($cache['session']))
     {
       header('Cache-Control: private, max-age='.self::ParseCache($cache['session']));
+
+      return;
     }
-    else if (isset($cache['global']))
+
+    if (isset($cache['global']))
     {
       header('Cache-Control: public, max-age='.self::ParseCache($cache['global']));
+
+      return;
     }
-    // session, local, global
+
+    if (isset($cache['no']))
+    {
+      if (in_array(['global', 'session'], $cache['no']))
+        header('Cache-Control: no-cache, no-store');
+
+      return;
+    }
   }
 
   static private function ParseCache( $str )

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -44,7 +44,6 @@ class phoxy_return_worker
     if (!isset($this->prepared))
       $this->Prepare();
 
-    header('Content-Type: application/json; charset=utf-8');
     return $this->prepared;
   }
 

--- a/server/phoxy_return_worker.php
+++ b/server/phoxy_return_worker.php
@@ -43,6 +43,8 @@ class phoxy_return_worker
   {
     if (!isset($this->prepared))
       $this->Prepare();
+
+    header('Content-Type: application/json; charset=utf-8');
     return $this->prepared;
   }
 

--- a/server/rpc_string_parser.php
+++ b/server/rpc_string_parser.php
@@ -117,9 +117,7 @@ class rpc_string_parser
     $pos++;
     $argstring = substr($token, $pos, $length - $pos - 1);
 
-    $unescaped = str_replace(
-      ["%28", "%29", "%3F", "%23", "%5C"],
-      ["(", ")", "?", "#", "\\"], $argstring);
+    $unescaped = rawurldecode($argstring);
     $args = json_decode("[$unescaped]");
 
     if ($args === null && strlen($unescaped) > 0)

--- a/server/virtual_namespace_helper.php
+++ b/server/virtual_namespace_helper.php
@@ -2,17 +2,21 @@
 $code = file_get_contents($file);
 $obj = null;
 
-$tempns = uniqid('phoxy\fork_');
+if ($classname != 'phoxy')
+{
+  $tempns = uniqid('phoxy\fork_');
 
-$header = <<<END
+  $header = <<<END
   namespace $tempns;
 
   use \phoxy as phoxy;
 END;
 
-$code = str_replace('<?php', $header, $code);
-$code = preg_replace('/ api\s*\n/', '\\api', $code);
+  $code = str_replace('<?php', $header, $code);
+  $code = preg_replace('/ api\s*\n/', ' \\api', $code);
 
-eval($code);
 
-$classname = "\\".$tempns."\\$module";
+  eval($code);
+
+  $classname = "\\".$tempns."\\$module";
+}

--- a/server/virtual_namespace_helper.php
+++ b/server/virtual_namespace_helper.php
@@ -4,7 +4,13 @@ $obj = null;
 
 $tempns = uniqid('phoxy\fork_');
 
-$code = str_replace('<?php', 'namespace '.$tempns.';', $code);
+$header = <<<END
+  namespace $tempns;
+
+  use \phoxy as phoxy;
+END;
+
+$code = str_replace('<?php', $header, $code);
 $code = preg_replace('/ api\s*\n/', '\\api', $code);
 
 eval($code);

--- a/subsystem/api.js
+++ b/subsystem/api.js
@@ -151,7 +151,7 @@ phoxy._.api =
         return str.replace(regexp,
           function(matched)
           {
-            return escape(escape(matched));
+            return escape(matched);
           });
       }
 

--- a/subsystem/api.js
+++ b/subsystem/api.js
@@ -29,7 +29,15 @@ phoxy.api =
 
       phoxy._.api.ajax(phoxy.Config()['api_dir'] + "/" + url, function ajax_callback(response)
         {
-          var data = JSON.parse(response);
+          try
+          {
+            var data = JSON.parse(response);
+          } catch (e)
+          {
+            phoxy.Log(1, url, [response]);
+            throw "Unable to decode JSON";
+          }
+
 
           // http://stackoverflow.com/questions/4215737/convert-array-to-object
           if (Array.isArray(data.data))

--- a/subsystem/early.js
+++ b/subsystem/early.js
@@ -118,7 +118,12 @@ phoxy._.EarlyStage.Compile = function()
     delete phoxy[system_name];
   }
 
-  if (phoxy._.prestart.sync_cascade)
+  var sync_cascade =
+    typeof phoxy._.prestart.sync_cascade != 'undefined'
+    ? phoxy._.prestart.sync_cascade
+    : phoxy.Config()['sync_cascade'];
+
+  if (sync_cascade)
   {
     phoxy.state.sync_cascade = true;
     phoxy._.render.RenderStrategy = phoxy._.render.SyncRender_Strategy;

--- a/subsystem/early.js
+++ b/subsystem/early.js
@@ -1,7 +1,31 @@
 phoxy._.EarlyStage.ajax = function (url, callback, data, x)
 {
+
+
   function ajax_Fetch(url, callback, data, x)
   {
+    var fetch_params =
+    {
+      'headers':
+      {
+        'X-Lain': 'Wake up',
+        'Content-type': 'application/x-www-form-urlencoded',
+      },
+      'credentials': 'include',
+    };
+
+    if (data)
+    {
+      fetch_params.method = 'post';
+      fetch_params.body = data;
+    }
+
+    function FetchPromise(response)
+    {
+      response.text().then(callback);
+    }
+
+    window.fetch(url, fetch_params).then(FetchPromise);
   }
 
   function ajax_XMLHttpRequest(url, callback, data, x)

--- a/subsystem/early.js
+++ b/subsystem/early.js
@@ -1,20 +1,37 @@
 phoxy._.EarlyStage.ajax = function (url, callback, data, x)
-{  // https://gist.github.com/Xeoncross/7663273
-  try
+{
+  function ajax_Fetch(url, callback, data, x)
   {
-    x = new(window.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
-    x.open(data ? 'POST' : 'GET', url, 1);
-    x.setRequestHeader('X-Lain', 'Wake up');
-    x.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
-    x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
-    x.onreadystatechange = function () {
-      x.readyState > 3 && callback && callback(x.responseText, x);
-    };
-    x.send(data)
-  } catch (e)
-  {
-    window.console && console.log(e);
   }
+
+  function ajax_XMLHttpRequest(url, callback, data, x)
+  {
+    try
+    {
+      x = new (window.XMLHttpRequest || ActiveXObject)('MSXML2.XMLHTTP.3.0');
+
+      x.open(data ? 'POST' : 'GET', url, 1);
+
+      x.setRequestHeader('X-Lain', 'Wake up');
+      x.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+
+      x.onload = function () {
+        callback(x.responseText, x);
+      };
+
+      x.send(data)
+    } catch (e)
+    {
+      window.console && console.log(e);
+    }
+  }
+
+  if (typeof window.fetch != 'undefined')
+    phoxy._.EarlyStage.ajax = ajax_Fetch;
+  else
+    phoxy._.EarlyStage.ajax = ajax_XMLHttpRequest;
+
+  phoxy._.EarlyStage.ajax.apply(this, arguments);
 };
 
 

--- a/subsystem/enjs_overload.js
+++ b/subsystem/enjs_overload.js
@@ -25,6 +25,7 @@ phoxy._.enjs =
 
       phoxy._.internal.Override(EJS.Canvas.across.prototype, 'CascadeDesign', phoxy._.enjs.CascadeDesign);
       phoxy._.internal.Override(EJS.Canvas.across.prototype, 'CascadeRequest', phoxy._.enjs.CascadeRequest);
+      phoxy._.internal.Override(EJS.Canvas.across.prototype, 'CascadeSupply', phoxy._.enjs.CascadeSupply);
       phoxy._.internal.Override(EJS.Canvas.across.prototype, 'ForeachDesign', phoxy._.enjs.ForeachDesign);
       phoxy._.internal.Override(EJS.Canvas.across.prototype, 'ForeachRequest', phoxy._.enjs.ForeachRequest);
     }
@@ -172,6 +173,26 @@ phoxy._.enjs =
 
       this.escape().log("Request", url);
       return phoxy._.enjs.CascadeInit(this, url, undefined, callback, tag || "<CascadeRequest>");
+    }
+  ,
+  CascadeSupply: function(design, url, callback, tag)
+    {
+      if (typeof url !== 'string' && !Array.isArray(url))
+        return phoxy.Log(1, "Are you sure that URL parameters of CascadeRequest right?");
+
+      this.escape().log("Supply", design, url);
+
+      // Workaround issue caused cascade support array/string types
+      // - main types for url handling
+      function hook_data_ready(cb)
+      {
+        phoxy.AJAX(url, function (data)
+        {
+          cb(data.data);
+        });
+      }
+
+      return phoxy._.enjs.CascadeInit(this, design, hook_data_ready, callback, tag || "<CascadeRequest>");
     }
   ,
   ShortcutCallback: function(k, callback)

--- a/subsystem/enjs_overload.js
+++ b/subsystem/enjs_overload.js
@@ -146,7 +146,7 @@ phoxy._.enjs =
       }
 
       // Handling non arrays (ex: strings) as data objects
-      if (typeof data != 'object' && typeof data != 'undefined')
+      if (['object', 'undefined', 'function'].indexOf(typeof data) == -1)
         data = { data: data };
 
       var ancor = phoxy.DeferRender(ejs, data, CBHook, tag);

--- a/subsystem/render.js
+++ b/subsystem/render.js
@@ -57,6 +57,9 @@ phoxy._.render =
       {
         phoxy._.render.CheckIfMultiplySpawned(target, ejs, data);
         phoxy._.render.Replace.call(phoxy, target, obj.html, arguments);
+
+        // Flag ENJS that anchor appeared
+        obj.try_discover_dom();
       }
 
       function async_strategy_birth(obj, ejs, data)
@@ -89,6 +92,9 @@ phoxy._.render =
       {
         phoxy._.render.AfterENJSFinished(target, obj, ejs, data, rendered_callback);
         phoxy._.render.Replace.call(phoxy, target, obj.html, arguments);
+
+        // Flag ENJS that anchor appeared
+        obj.try_discover_dom();
       }
 
       phoxy._.time.Appeared(target, sync_strategy_wait_for_apperance);

--- a/subsystem/render.js
+++ b/subsystem/render.js
@@ -57,9 +57,6 @@ phoxy._.render =
       {
         phoxy._.render.CheckIfMultiplySpawned(target, ejs, data);
         phoxy._.render.Replace.call(phoxy, target, obj.html, arguments);
-
-        for (var k in obj.defer)
-          obj.defer[k]();
       }
 
       function async_strategy_birth(obj, ejs, data)
@@ -394,22 +391,8 @@ phoxy._.birth.prototype =
   ,
   Render: function(design, data, cb)
   {
-    var async = typeof cb === 'function';
-
-    if (design.indexOf(".ejs") === -1)
-        design += ".ejs";
-
-    var callback = async ? WhenReady : undefined;
-    var obj =
-    {
-      domain: phoxy.Config().site,
-      url: design,
-    };
-
-    var ejs = new EJS(obj, callback);
-
     var that = this;
-    function WhenReady()
+    function WhenReady(ejs)
     {
       function log()
       {
@@ -428,7 +411,21 @@ phoxy._.birth.prototype =
       return obj;
     }
 
+    if (design.indexOf(".ejs") === -1)
+        design += ".ejs";
+
+    var async = typeof cb === 'function';
+
+    var callback = async ? WhenReady : undefined;
+    var obj =
+    {
+      domain: phoxy.Config().site,
+      url: design,
+    };
+
+    var ejs = new EJS(obj, callback);
+
     if (!async)
-      return WhenReady();
+      return WhenReady(ejs);
   }
 }

--- a/subsystem/render.js
+++ b/subsystem/render.js
@@ -200,7 +200,8 @@ phoxy._.birth = function(will, spirit, callback, raw_output)
   console.time("phoxy.birth " + this.birth_id);
   this.callback = function birth_log_report()
   {
-    this.DumpLog();
+    if (phoxy.state.verbose_birth)
+      this.DumpLog();
 
     callback.apply(this, arguments);
   }

--- a/subsystem/time.js
+++ b/subsystem/time.js
@@ -33,8 +33,8 @@ phoxy._.time =
         return callback();
 
       var
-        check_timeout = 60, // 1 minute for render to complete
-        check_delay = 500; // check every 500ms
+        check_timeout = phoxy.state.wait.timeout_seconds, // 1 minute for render to complete
+        check_delay = phoxy.state.wait.check_every_ms; // check every 500ms
 
       if (timeout !== undefined)
         check_timeout = timeout;


### PR DESCRIPTION
**Server:**
- Support PHP 7
- Update to latest ENJS features (rendering without delay)
- Make timer delays variadic with `phoxy.state.wait`
- Refactor and fix bugs in `phoxy_sys_api`
- Use var_dump for api debug (phoxy_conf `debug_api`)
- Suppress any warnings in api, return clean json (phoxy_conf `buffered_output`)
- Modify cascade type from server (phoxy_conf `sync_cascade`)
- Cleaner way to alter cache `phoxy::SetCacheTimeout` and `phoxy::SetCacheTimeoutTimestamp`
- Refactor caching, `'no'` is represents 'if nothing else specified - disable' 
- Cache new letter 'w' - weeks

**Client:**
- Hook json decode issues
- Refactor click subsystem, `not-phoxy` is deprecated
- Prefer HTML5 fetch when possible
- `CascadeSupply` - cascade render with unknown dataset (similar to `DeferRender(..., url)`)
- Announce render states, moving forward without `phoxy.Defer` reschedule. (Speedup)
